### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,14 @@
+# These are supported funding model platforms
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username e.g., user1
+open_collective: dekusms
+ko_fi: # Replace with a single Ko-fi username e.g., user1
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+polar: # Replace with a single Polar username e.g., user1
+buy_me_a_coffee: # Replace with a single Buy Me a Coffee username e.g., user1
+thanks_dev: # Replace with a single thanks.dev username e.g., u/gh/user1
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username e.g., user1
+issuehunt: # Replace with a single IssueHunt username e.g., user1
+otechie: # Replace with a single Otechie username e.g., user1
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
Hi,

This small PR adds a FUNDING.yml to your repo. Even if you didn't subscribed to the [GitHub Sponsors Program](https://github.com/sponsors), it'll be useful : F-Droid is taking the donation links from this file to show them on the [website](https://f-droid.org/) and in the Android client.

It also allows you to have the control over the donation links shown by F-Droid website. For example, if you later want to add a Liberapay account, or add a donate link, you can do it by yourself by adjusting this file in your own repo, without having to open a MR on F-Droid side to add the information in the [metadata file](https://gitlab.com/fdroid/fdroiddata). This reduce the load on the F-Droid repos and Teams, and give back the power to the developer. The new information added/changed in this FUNDING.yml need to be covered by a new tag/release to be taken in account by our F-Droid bot.

Please note that GitHub doesn't want to add support for cryptos for now, so we still have to host this kind of information in our metadata files (you can't put your bitcoin adress in the FUNDING.yml file) if any...

Please ask me if you have any question regarding this subject.