### PR TITLE
Update German tranlation strings.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -287,7 +287,7 @@
     <string name="reset_and_import">Zurücksetzen und importieren</string>
     <string name="block">Blockieren</string>
     <string name="unblock">Entsperren</string>
-    <string name="language_polish">Polieren</string>
+    <string name="language_polish">Polnisch</string>
     <string name="welcome_image">Willkommensbild</string>
     <string name="remote_listeners">Remote-Hörer</string>
     <string name="port">"Port: "</string>


### PR DESCRIPTION
Polish was translated as polish(cleaner) not as polish(language) in German. Fixed that.
A few other Strings looked suspicious to me, but well couldn't verify the context inside the App so I'm gonna leave it at that for now.