### PR TITLE
Fixed jitpack build issue.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ android {
 
 dependencies {
     implementation 'com.github.smswithoutborders:lib_smsmms_android:73432ef'
-    implementation 'com.github.smswithoutborders:lib_signal_double_ratchet_java:ad727a5'
+    implementation 'com.github.smswithoutborders:lib_signal_double_ratchet_java:ad727a57b3'
     implementation libs.androidx.room.testing
     implementation libs.androidx.activity
     implementation libs.androidx.espresso.core


### PR DESCRIPTION
This fix addresses issue https://github.com/dekusms/DekuSMS-Android/issues/525.

What changed?
Used a 10-digit commit id, instead of 7-digits.