### PR TITLE
Add missing string resources for remote listeners

### DIFF
--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/RMQ/RMQLongRunningConnectionWorker.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/RMQ/RMQLongRunningConnectionWorker.kt
@@ -36,14 +36,16 @@ class RMQLongRunningConnectionWorker(context: Context, parameters: WorkerParamet
                 notificationIntent,
                 PendingIntent.FLAG_IMMUTABLE)
 
-        val title = "Long running..."
+        val title = applicationContext
+            .getString(R.string.remote_listeners_long_running_notification_title)
         val description = ""
 
         val notification =
             NotificationCompat.Builder( applicationContext,
                 applicationContext.getString(R.string.running_gateway_clients_channel_id))
                 .setContentTitle(title)
-                .setContentText("Status")
+                .setContentText(applicationContext
+                    .getString(R.string.remote_listeners_notification_status))
                 .setSmallIcon(R.drawable.ic_stat_name)
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setSilent(true)

--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/RemoteListenerConnectionService.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/RemoteListenerConnectionService.kt
@@ -225,23 +225,24 @@ class RemoteListenerConnectionService : Service() {
                         notificationIntent,
                         PendingIntent.FLAG_IMMUTABLE)
 
-        val title = "$numberOfActiveRemoteListeners Active..."
-        val description = ""
-            .plus("# Failed to start: ")
-            .plus("$numberFailedToStart\n")
-            .plus("# Waiting to start: ")
-            .plus("$numberWaitingToStart\n")
-            .plus("# Starting: ")
-            .plus("$numberStarting\n")
-            .plus("# Connected: ")
-            .plus(numberStarted)
+        val title = getString(
+            R.string.remote_listeners_active_notification_title,
+            numberOfActiveRemoteListeners
+        )
+        val description = getString(
+            R.string.remote_listeners_notification_body,
+            numberFailedToStart,
+            numberWaitingToStart,
+            numberStarting,
+            numberStarted
+        )
 
         val notification =
                 NotificationCompat.Builder(
                     applicationContext,
                     getString(R.string.running_gateway_clients_channel_id))
                     .setContentTitle(title)
-                    .setContentText("Status")
+                    .setContentText(getString(R.string.remote_listeners_notification_status))
                     .setSmallIcon(R.drawable.ic_stat_name)
                     .setPriority(NotificationCompat.PRIORITY_LOW)
                     .setSilent(true)

--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/components/Permissions.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/components/Permissions.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.afkanerd.deku.DefaultSMS.R
 import com.afkanerd.deku.RemoteListeners.ui.requiredNotificationsPermissions
 import com.afkanerd.deku.RemoteListeners.ui.requiredReadPhoneStatePermissions
 import com.afkanerd.deku.RemoteListeners.ui.requiredReceiveSMSPermission
@@ -39,10 +41,11 @@ fun NotificationPermissionComposable() {
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
                 isGranted ->
             if(isGranted) {
-                Toast.makeText(context, "Well done!", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, R.string.permission_notification_granted_toast,
+                    Toast.LENGTH_LONG).show()
             } else {
-                Toast.makeText(context, "We cannot do without this one...", Toast.LENGTH_LONG)
-                    .show()
+                Toast.makeText(context, R.string.permission_notification_denied_toast,
+                    Toast.LENGTH_LONG).show()
             }
         }
 
@@ -63,7 +66,7 @@ fun NotificationPermissionComposable() {
                 ) {
                     Icon(imageVector =  Icons.Outlined.Info, "", tint=MaterialTheme.colorScheme.secondary)
                     Text(
-                        "When not default SMS app, you need to grant permissions for listeners to show notifications when changing.",
+                        stringResource(R.string.permission_notification_rationale),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                         modifier = Modifier.padding(start=16.dp, end=16.dp, top=8.dp)
@@ -78,7 +81,7 @@ fun NotificationPermissionComposable() {
                     TextButton(onClick = {
                         getNotificationsPermissionsLauncher.launch(requiredNotificationsPermissions)
                     }) {
-                        Text("Grant notification permission")
+                        Text(stringResource(R.string.permission_grant_notification))
                     }
                 }
             }
@@ -93,9 +96,11 @@ fun PhoneStatePermissionComposable() {
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
                 isGranted ->
             if(isGranted) {
-                Toast.makeText(context, "Well done, carry on!", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, R.string.permission_phone_state_granted_toast,
+                    Toast.LENGTH_LONG).show()
             } else {
-                Toast.makeText(context, "You can at anytime...", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, R.string.permission_phone_state_denied_toast,
+                    Toast.LENGTH_LONG).show()
             }
         }
 
@@ -116,7 +121,7 @@ fun PhoneStatePermissionComposable() {
                 ) {
                     Icon(imageVector =  Icons.Outlined.Info, "", tint=MaterialTheme.colorScheme.secondary)
                     Text(
-                        "When not default SMS app, you need to grant permissions for listeners to check for sim status and dual sim information.",
+                        stringResource(R.string.permission_phone_state_rationale),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                         modifier = Modifier.padding(start=16.dp, end=16.dp, top=8.dp)
@@ -132,7 +137,7 @@ fun PhoneStatePermissionComposable() {
                         getReadPhoneStatePermissionsLauncher
                             .launch(requiredReadPhoneStatePermissions)
                     }) {
-                        Text("Grant phone state permission")
+                        Text(stringResource(R.string.permission_grant_phone_state))
                     }
                 }
             }
@@ -148,9 +153,11 @@ fun SMSPermissionComposable() {
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
                 isGranted ->
             if(isGranted) {
-                Toast.makeText(context, "Carry on activating...", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, R.string.permission_sms_granted_toast,
+                    Toast.LENGTH_LONG).show()
             } else {
-                Toast.makeText(context, "I'd be back!", Toast.LENGTH_LONG).show()
+                Toast.makeText(context, R.string.permission_sms_denied_toast,
+                    Toast.LENGTH_LONG).show()
             }
         }
 
@@ -174,7 +181,7 @@ fun SMSPermissionComposable() {
                 ) {
                     Icon(imageVector =  Icons.Outlined.Info, "", tint=MaterialTheme.colorScheme.secondary)
                     Text(
-                        "When not default SMS app, you need to grant permissions for listeners to send and receive delivery reports.",
+                        stringResource(R.string.permission_sms_rationale),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                         modifier = Modifier.padding(start=16.dp, end=16.dp, top=8.dp)
@@ -190,14 +197,14 @@ fun SMSPermissionComposable() {
                         TextButton(onClick = {
                             getSMSPermissionLauncher.launch(requiredSendSMSPermission)
                         }) {
-                            Text("Grant send sms permission")
+                            Text(stringResource(R.string.permission_grant_send_sms))
                         }
                     }
                     if(!smsReadSMSState.status.isGranted || LocalInspectionMode.current) {
                         TextButton(onClick = {
                             getSMSPermissionLauncher.launch(requiredReceiveSMSPermission)
                         }) {
-                            Text("Grant read sms permission")
+                            Text(stringResource(R.string.permission_grant_read_sms))
                         }
                     }
                 }

--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerModal.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerModal.kt
@@ -18,9 +18,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afkanerd.deku.DefaultSMS.BuildConfig
+import com.afkanerd.deku.DefaultSMS.R
 import com.example.compose.AppTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -57,18 +59,22 @@ fun RemoteListenerModal(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text("Configure Remote listener",
+                Text(stringResource(R.string.remote_listener_configure_title),
                     style = MaterialTheme.typography.titleMedium)
 
                 Spacer(modifier = Modifier.padding(8.dp))
 
                 Button(onClick = connectionCallback, modifier = Modifier.fillMaxWidth()) {
-                    Text(if(activated) "Deactivate" else "Activate")
+                    Text(stringResource(
+                        if(activated) R.string.gateway_client_customization_deactivate
+                        else R.string.gateway_client_customization_activate
+                    ))
                 }
                 Text(
-                    if(activated)
-                        "Deactivating stops the remote listener and tries to kill all remote connections."
-                    else "Activating begins the service that tries to connect this remote listener",
+                    stringResource(
+                        if(activated) R.string.remote_listener_deactivate_description
+                        else R.string.remote_listener_activate_description
+                    ),
                     style = MaterialTheme.typography.labelSmall,
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.secondary
@@ -76,11 +82,11 @@ fun RemoteListenerModal(
                 Spacer(modifier = Modifier.padding(16.dp))
 
                 Button(onClick = editCallback, modifier = Modifier.fillMaxWidth()) {
-                    Text("Edit" )
+                    Text(stringResource(R.string.edit))
                 }
 
                 TextButton(onClick = deleteCallback) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.delete), color = MaterialTheme.colorScheme.error)
                 }
             }
         }

--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerReadPhoneStatePermissionModal.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerReadPhoneStatePermissionModal.kt
@@ -20,10 +20,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afkanerd.deku.DefaultSMS.BuildConfig
+import com.afkanerd.deku.DefaultSMS.R
 import com.example.compose.AppTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,20 +57,20 @@ fun RemoteListenersReadPhoneStatePermissionModal(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    "Permission required!",
+                    stringResource(R.string.permission_required_title),
                     style = MaterialTheme.typography.titleMedium
                 )
 
                 Spacer(Modifier.padding(16.dp))
 
                 Text(
-                    "Grant permission to detect how many SIM cards you have on your device",
+                    stringResource(R.string.remote_listener_phone_state_permission_description),
                     textAlign = TextAlign.Center
                 )
 
                 Spacer(Modifier.padding(8.dp))
                 Text(
-                    "This would also auto fill useful information which can help you identify your various queues.",
+                    stringResource(R.string.remote_listener_phone_state_permission_hint),
                     style = MaterialTheme.typography.labelMedium,
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.secondary
@@ -76,7 +78,7 @@ fun RemoteListenersReadPhoneStatePermissionModal(
 
                 Spacer(Modifier.padding(12.dp))
                 Button(onClick = grantPermissionsCallback) {
-                    Text("Grant permission")
+                    Text(stringResource(R.string.permission_grant))
                 }
             }
         }

--- a/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerSMSPermissionsModal.kt
+++ b/app/src/main/java/com/afkanerd/deku/RemoteListeners/modals/RemoteListenerSMSPermissionsModal.kt
@@ -20,10 +20,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afkanerd.deku.DefaultSMS.BuildConfig
+import com.afkanerd.deku.DefaultSMS.R
 import com.example.compose.AppTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,20 +57,20 @@ fun RemoteListenerSMSPermissionsModal(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    "Permission required!",
+                    stringResource(R.string.permission_required_title),
                     style = MaterialTheme.typography.titleMedium
                 )
 
                 Spacer(Modifier.padding(16.dp))
 
                 Text(
-                    "Remote listeners sends messages and listen for delivery reports. This requires permission to read and write SMS messages.",
+                    stringResource(R.string.remote_listener_sms_permission_description),
                     textAlign = TextAlign.Center
                 )
 
                 Spacer(Modifier.padding(8.dp))
                 Text(
-                    "You can make the app your default SMS app, or choose to grant the necessary permissions",
+                    stringResource(R.string.remote_listener_sms_permission_hint),
                     style = MaterialTheme.typography.labelMedium,
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.secondary
@@ -76,7 +78,7 @@ fun RemoteListenerSMSPermissionsModal(
 
                 Spacer(Modifier.padding(16.dp))
                 Button(onClick = makeDefaultCallback) {
-                    Text("Make default")
+                    Text(stringResource(R.string.remote_listener_make_default))
                 }
             }
         }

--- a/app/src/main/java/com/afkanerd/deku/Router/ui/GatewayClientsMainView.kt
+++ b/app/src/main/java/com/afkanerd/deku/Router/ui/GatewayClientsMainView.kt
@@ -94,7 +94,7 @@ fun GatewayClientsMainView(
             DropdownMenuItem(
                 text = {
                     Text(
-                        text = "Add SMTP forwarder",
+                        text = stringResource(R.string.add_smtp_forwarders),
                         color = MaterialTheme.colorScheme.onBackground
                     )
                 },
@@ -113,7 +113,7 @@ fun GatewayClientsMainView(
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "go back"
+                            contentDescription = stringResource(R.string.go_back)
                         )
                     }
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -456,4 +456,40 @@
     <string name="secure_message_accepted">Secure message accepted</string>
     <string name="enter_subject">Enter subject</string>
 
+    <!-- Remote listeners: permissions -->
+    <string name="permission_required_title">Permission required!</string>
+    <string name="permission_grant">Grant permission</string>
+    <string name="permission_grant_notification">Grant notification permission</string>
+    <string name="permission_grant_phone_state">Grant phone state permission</string>
+    <string name="permission_grant_send_sms">Grant send sms permission</string>
+    <string name="permission_grant_read_sms">Grant read sms permission</string>
+    <string name="permission_notification_rationale">When not default SMS app, you need to grant permissions for listeners to show notifications when changing.</string>
+    <string name="permission_phone_state_rationale">When not default SMS app, you need to grant permissions for listeners to check for sim status and dual sim information.</string>
+    <string name="permission_sms_rationale">When not default SMS app, you need to grant permissions for listeners to send and receive delivery reports.</string>
+    <string name="permission_notification_granted_toast">Well done!</string>
+    <string name="permission_notification_denied_toast">We cannot do without this one…</string>
+    <string name="permission_phone_state_granted_toast">Well done, carry on!</string>
+    <string name="permission_phone_state_denied_toast">You can at anytime…</string>
+    <string name="permission_sms_granted_toast">Carry on activating…</string>
+    <string name="permission_sms_denied_toast">I\'d be back!</string>
+
+    <!-- Remote listeners: modals -->
+    <string name="remote_listener_sms_permission_description">Remote listeners sends messages and listen for delivery reports. This requires permission to read and write SMS messages.</string>
+    <string name="remote_listener_sms_permission_hint">You can make the app your default SMS app, or choose to grant the necessary permissions</string>
+    <string name="remote_listener_make_default">Make default</string>
+    <string name="remote_listener_phone_state_permission_description">Grant permission to detect how many SIM cards you have on your device</string>
+    <string name="remote_listener_phone_state_permission_hint">This would also auto fill useful information which can help you identify your various queues.</string>
+    <string name="remote_listener_configure_title">Configure Remote listener</string>
+    <string name="remote_listener_activate_description">Activating begins the service that tries to connect this remote listener</string>
+    <string name="remote_listener_deactivate_description">Deactivating stops the remote listener and tries to kill all remote connections.</string>
+
+    <!-- Remote listeners: notifications -->
+    <string name="remote_listeners_active_notification_title">%1$d active…</string>
+    <string name="remote_listeners_long_running_notification_title">Long running…</string>
+    <string name="remote_listeners_notification_status">Status</string>
+    <string name="remote_listeners_notification_body"># Failed to start: %1$d\n# Waiting to start: %2$d\n# Starting: %3$d\n# Connected: %4$d</string>
+
+    <!-- Router -->
+    <string name="add_smtp_forwarders">Add SMTP forwarder</string>
+
 </resources>


### PR DESCRIPTION
Remote listener permission rationales, modals, foreground service
notifications and the SMTP forwarder menu item had their text
hardcoded in Kotlin, making them untranslatable.

Move them to values/strings.xml (28 keys) and reference them via
stringResource / getString. Notification bodies now use positional
format arguments instead of string concatenation.

Once this PR is merged, I'll improve the app in French. 😊